### PR TITLE
Update to Stride 4.3.0.2507 (net10.0)

### DIFF
--- a/StrideCommunity.ImGuiDebug.csproj
+++ b/StrideCommunity.ImGuiDebug.csproj
@@ -3,14 +3,14 @@
     <OutputType>Library</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
 	  <PackageReference Include="Hexa.NET.ImGui" Version="2.0.1" />
-    <PackageReference Include="Stride.Core" Version="4.2.0.2188" PrivateAssets="contentfiles;analyzers" />
-    <PackageReference Include="Stride.Engine" Version="4.2.0.2188" PrivateAssets="contentfiles;analyzers" />
+    <PackageReference Include="Stride.Core" Version="4.3.0.2507" PrivateAssets="contentfiles;analyzers" />
+    <PackageReference Include="Stride.Engine" Version="4.3.0.2507" PrivateAssets="contentfiles;analyzers" />
 
-    <PackageReference Include="Stride.Core.Assets.CompilerApp" Version="4.2.0.2188" PrivateAssets="contentfiles; analyzers" IncludeAssets="build; buildtransitive" />
+    <PackageReference Include="Stride.Core.Assets.CompilerApp" Version="4.3.0.2507" PrivateAssets="contentfiles; analyzers" IncludeAssets="build; buildtransitive" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Effects\ImGuiShader.sdsl.cs">


### PR DESCRIPTION
Bumps the project to the current Stride release, **4.3.0.2507**, so the sample keeps building against an up-to-date Stride install.

### What changed
Just the csproj — **no code changes**:

- `Stride.Core`, `Stride.Engine`, `Stride.Core.Assets.CompilerApp`: `4.2.0.2188` → `4.3.0.2507`
- `TargetFramework`: `net8.0` → `net10.0`

4.2 → 4.3 is source-compatible for everything this project uses: `PipelineState.New` still takes the descriptor by `ref`, the asset compiler is still `Stride.Core.Assets.CompilerApp`, and shaders still use the physical-file `.sdsl.cs` mechanism. (Those all changed in 4.4, but not in 4.3.)

The `net8.0 → net10.0` move is **required**, not cosmetic: Stride `4.3.0.2507` ships only `lib/net10.0` assemblies, so a net8 project can't reference it.

### Heads-up for maintainers
This moves the sample off 4.2/net8.0 rather than alongside it — anyone still pinned to Stride 4.2 would no longer be able to build this as-is. If you'd rather keep 4.2 working, I'm happy to redo it as a multi-target (`net8.0;net10.0` with conditional `Stride.*` versions) instead of a straight bump — just let me know.

### Verification
`dotnet build -c Debug` restores 4.3.0.2507 and compiles clean (0 errors; only the repo's pre-existing warnings about obsolete `DataPointer` overloads and unused fields).